### PR TITLE
FIRRTL/Chisel version bumps + reduction unary operators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,9 @@ resolvers ++= Seq(
 
 // Managed dependency on latest FIRRTL + chisel3
 //libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.2.0-RC1"
-libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.3.2"
+libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.4.2"
 //libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.2.0-RC1"
-libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.3.2"
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.2"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.6.9"
 

--- a/src/main/scala/chiselucl/backend/UclidEmitter.scala
+++ b/src/main/scala/chiselucl/backend/UclidEmitter.scala
@@ -111,7 +111,7 @@ class UclidEmitter extends Transform with DependencyAPIMigration {
       }
     case Andr | Orr | Xorr =>
       // Simulate bitwise reduction operators
-      (0 until get_width(p.args.head.tpe)).map(i => s"${arg0}[$i]").mkString(
+      (0 until get_width(p.args.head.tpe)).map(i => s"$arg0[$i:$i]").mkString(
         p.op match {
           case Andr => " & "
           case Orr => " | "


### PR DESCRIPTION
Fixes #3, and also adds translation for a few additional unary operators (mostly bit reductions).